### PR TITLE
Ensure that behaviors['class'] is set

### DIFF
--- a/widgets/AuditTrail.php
+++ b/widgets/AuditTrail.php
@@ -262,7 +262,7 @@ class AuditTrail extends \yii\grid\GridView
 	protected function getBehaviorInstance()
 	{
 		foreach ($this->model->behaviors() as $name=>$config) {
-			if (isset($config['class'] && $config['class'] == AuditTrailBehavior::className()) {
+			if (isset($config['class']) && $config['class'] == AuditTrailBehavior::className()) {
 				return $this->model->getBehavior($name);
 			}
 		}		

--- a/widgets/AuditTrail.php
+++ b/widgets/AuditTrail.php
@@ -262,7 +262,7 @@ class AuditTrail extends \yii\grid\GridView
 	protected function getBehaviorInstance()
 	{
 		foreach ($this->model->behaviors() as $name=>$config) {
-			if ($config['class'] == AuditTrailBehavior::className()) {
+			if (isset($config['class'] && $config['class'] == AuditTrailBehavior::className()) {
 				return $this->model->getBehavior($name);
 			}
 		}		


### PR DESCRIPTION
If behaviours does not have class attribute, then this function will fail. E.g. it will fail if the model `behaviours()` is as follow:

```
public function behaviors()
    {
        return [
            BlameableBehavior::className(),
            TimestampBehavior::className(),            
            'audittrail' => [
                'class' => AuditTrailBehavior::className(),
                'ignoredAttributes'=>['created_at','updated_at', 
                    'created_by', 'updated_by'],
            ]
        ];
    }   
```