### PR TITLE
Fixed AuditTrailBehavior::onAfterUpdate() for PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+###### v.1.0.3
+- fixed AuditTrailBehavior::onAfterUpdate() for PHP 8.1
+
 ###### v.1.0.2
 - fixed bug in AuditTrail widget
 

--- a/behaviors/AuditTrailBehavior.php
+++ b/behaviors/AuditTrailBehavior.php
@@ -170,7 +170,7 @@ class AuditTrailBehavior extends \yii\base\Behavior
 			$newVal = static::castValue($oldVal, $this->owner->{$attrName});
 
 			//additional comparison after casting
-			if ((is_string($newVal) && call_user_func($this->caseSensitive ? 'strcmp' : 'strcasecmp', $oldVal, $newVal) === 0) || $oldVal === $newVal) {
+			if ($oldVal === $newVal || (is_string($newVal) && is_string($oldVal) && call_user_func($this->caseSensitive ? 'strcmp' : 'strcasecmp', $oldVal, $newVal) === 0)) {
 				continue;
 			}
 


### PR DESCRIPTION
Making sure that $oldVal is a string before comparing it to $newVal